### PR TITLE
chore: convert mesh-gradient to TypeScript and fix Next.js 16 image warning

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,7 @@ const nextConfig: NextConfig = {
     formats: ["image/webp", "image/avif"],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+    qualities: [75, 100],
   },
 
   // Security headers

--- a/src/components/gradient/mesh-gradient/index.tsx
+++ b/src/components/gradient/mesh-gradient/index.tsx
@@ -3,7 +3,11 @@ import { useEffect } from "react"
 import clsx from "clsx"
 import s from "./mesh-gradient.module.scss"
 
-const MeshGradient = ({ className = undefined }) => {
+type MeshGradientProps = {
+  className?: string
+}
+
+const MeshGradient = ({ className }: MeshGradientProps) => {
   useEffect(() => {
     // @ts-expect-error - Dynamic import of vanilla JS gradient library
     import("./raw").then(({ gradient }) => gradient.initGradient("#gradient-canvas"))


### PR DESCRIPTION
## Summary

Converts the last remaining `.js` file in the project to TypeScript and fixes a forward-compatibility warning for Next.js 16.

---

## Changes

### `mesh-gradient/index.js` -> `index.tsx`

The component is straightforward — a single React component that dynamically imports the vanilla JS WebGL library (`raw.js`) and renders a `<canvas>`. The conversion adds an explicit `MeshGradientProps` type for the `className` prop.

`raw.js` is intentionally kept as JavaScript. It is a third-party WebGL port (Stripe gradient animation) with ~800 lines of complex WebGL internals. Adding types to it would carry high risk of introducing bugs in stable, untouched code with no meaningful benefit. `allowJs: true` in `tsconfig.json` covers it.

### `next.config.ts` — `images.qualities`

Added `qualities: [75, 100]` to the image config. Next.js 16 will require this to be explicitly set when using non-default quality values. `75` is the Next.js default, `100` is used on the avatar in the header.

## Files

| File | Change |
|---|---|
| `src/components/gradient/mesh-gradient/index.tsx` | New — TypeScript version of the component |
| `src/components/gradient/mesh-gradient/index.js` | Deleted |
| `next.config.ts` | Added `images.qualities: [75, 100]` |