### PR TITLE
feat(hero): retro neon hero animation update

### DIFF
--- a/src/sections/hero/hero.module.scss
+++ b/src/sections/hero/hero.module.scss
@@ -82,44 +82,47 @@
   }
 }
 
-@keyframes neonPulse {
-  0%,
-  100% {
-    text-shadow:
-      0 0 1px #d100b1,
-      0 -1px 3px rgba(255, 255, 255, 0.85),
-      0 1px 3px rgba(0, 0, 0, 0.5),
-      0 0 20px #d100b1,
-      0 0 52px rgba(209, 0, 177, 0.85);
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes neonPulse {
+    0%,
+    100% {
+      text-shadow:
+        0 0 1px #d100b1,
+        0 -1px 3px rgba(255, 255, 255, 0.85),
+        0 1px 3px rgba(0, 0, 0, 0.5),
+        0 0 20px #d100b1,
+        0 0 52px rgba(209, 0, 177, 0.85);
+    }
+
+    50% {
+      text-shadow:
+        0 0 2px #d100b1,
+        0 -1px 4px rgba(255, 255, 255, 0.92),
+        0 1px 3px rgba(0, 0, 0, 0.5),
+        0 0 26px #d100b1,
+        0 0 60px rgba(209, 0, 177, 0.92);
+    }
   }
 
-  50% {
-    text-shadow:
-      0 0 2px #d100b1,
-      0 -1px 4px rgba(255, 255, 255, 0.92),
-      0 1px 3px rgba(0, 0, 0, 0.5),
-      0 0 26px #d100b1,
-      0 0 60px rgba(209, 0, 177, 0.92);
-  }
-}
-
-.subtitlePulsing {
-  animation: neonPulse 3s ease-in-out infinite;
-}
-
-@keyframes triangleGlow {
-  0%,
-  100% {
-    filter: drop-shadow(0 0 4px #36e2f8) drop-shadow(0 0 14px rgba(54, 226, 248, 0.4));
+  .subtitlePulsing {
+    animation: neonPulse 3s ease-in-out infinite;
   }
 
-  50% {
-    filter: drop-shadow(0 0 6px #36e2f8) drop-shadow(0 0 20px rgba(54, 226, 248, 0.58));
-  }
-}
+  @keyframes triangleGlow {
+    0%,
+    100% {
+      filter: drop-shadow(0 0 6px rgba(54, 226, 248, 0.55));
+    }
 
-.trianglePulsing {
-  animation: triangleGlow 4s ease-in-out infinite;
+    50% {
+      filter: drop-shadow(0 0 12px rgba(54, 226, 248, 0.8));
+    }
+  }
+
+  .trianglePulsing {
+    will-change: filter;
+    animation: triangleGlow 4s ease-in-out infinite;
+  }
 }
 
 .triangle {

--- a/src/sections/hero/hero.module.scss
+++ b/src/sections/hero/hero.module.scss
@@ -79,6 +79,31 @@
   }
 }
 
+@keyframes neonPulse {
+  0%,
+  100% {
+    text-shadow:
+      0 0 1px #d100b1,
+      0 -1px 3px rgba(255, 255, 255, 0.8),
+      0 1px 3px rgba(0, 0, 0, 0.5),
+      0 0 15px #d100b1,
+      0 0 45px rgba(209, 0, 177, 0.8);
+  }
+
+  50% {
+    text-shadow:
+      0 0 2px #d100b1,
+      0 -1px 5px rgba(255, 255, 255, 0.95),
+      0 1px 3px rgba(0, 0, 0, 0.5),
+      0 0 24px #d100b1,
+      0 0 68px rgba(209, 0, 177, 0.95);
+  }
+}
+
+.subtitlePulsing {
+  animation: neonPulse 3s ease-in-out infinite;
+}
+
 .triangle {
   stroke-dasharray: 1200;
   stroke-dashoffset: 1200;

--- a/src/sections/hero/hero.module.scss
+++ b/src/sections/hero/hero.module.scss
@@ -67,6 +67,7 @@
   text-align: center;
   text-decoration: underline;
   text-shadow: var(--glow);
+  transform: rotate(-8deg);
   will-change: transform;
 
   @include tablet {

--- a/src/sections/hero/hero.module.scss
+++ b/src/sections/hero/hero.module.scss
@@ -22,6 +22,7 @@
 
 .title {
   position: absolute;
+  z-index: 2;
   background: linear-gradient(
     to bottom,
     var(--blue),
@@ -54,6 +55,7 @@
 
 .subtitle {
   position: absolute;
+  z-index: 2;
   top: 80px;
   width: 100%;
   color: var(--pink);
@@ -84,19 +86,19 @@
   100% {
     text-shadow:
       0 0 1px #d100b1,
-      0 -1px 3px rgba(255, 255, 255, 0.8),
+      0 -1px 3px rgba(255, 255, 255, 0.85),
       0 1px 3px rgba(0, 0, 0, 0.5),
-      0 0 15px #d100b1,
-      0 0 45px rgba(209, 0, 177, 0.8);
+      0 0 20px #d100b1,
+      0 0 52px rgba(209, 0, 177, 0.85);
   }
 
   50% {
     text-shadow:
       0 0 2px #d100b1,
-      0 -1px 5px rgba(255, 255, 255, 0.95),
+      0 -1px 4px rgba(255, 255, 255, 0.92),
       0 1px 3px rgba(0, 0, 0, 0.5),
-      0 0 24px #d100b1,
-      0 0 68px rgba(209, 0, 177, 0.95);
+      0 0 26px #d100b1,
+      0 0 60px rgba(209, 0, 177, 0.92);
   }
 }
 
@@ -104,9 +106,22 @@
   animation: neonPulse 3s ease-in-out infinite;
 }
 
+@keyframes triangleGlow {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 4px #36e2f8) drop-shadow(0 0 14px rgba(54, 226, 248, 0.4));
+  }
+
+  50% {
+    filter: drop-shadow(0 0 6px #36e2f8) drop-shadow(0 0 20px rgba(54, 226, 248, 0.58));
+  }
+}
+
+.trianglePulsing {
+  animation: triangleGlow 4s ease-in-out infinite;
+}
+
 .triangle {
-  stroke-dasharray: 1200;
-  stroke-dashoffset: 1200;
   opacity: 0;
 
   @include mobile {

--- a/src/sections/hero/index.tsx
+++ b/src/sections/hero/index.tsx
@@ -18,6 +18,21 @@ const Hero = () => {
     tl.current = gsap.timeline()
     const heroSection = containerRef.current
 
+    // neon color states — mimic the CodePen technique: swap color+shadow, never touch opacity
+    const unlitColor = "#3d0a30"
+    const litColor = "#d100b1"
+    // unlit tube: very faint outline-like shadow, simulates the glass tube shape
+    const unlitShadow =
+      "0 0 1px rgba(180, 20, 140, 0.25), 0 0 3px rgba(180, 20, 140, 0.12)"
+    // flash bursts (flashes 1 & 2) — instant, full power
+    const flashShadow =
+      "0 0 2px #ff00d9, 0 -1px 5px rgba(255,255,255,0.95), 0 1px 3px rgba(0,0,0,0.5), 0 0 30px #d100b1, 0 0 70px rgba(209,0,177,0.95)"
+    // seed shadow for the "catches" transition — minimal, glow starts from here
+    const ignitionShadow =
+      "0 0 1px rgba(209,0,177,0.4), 0 -1px 2px rgba(255,255,255,0.2), 0 1px 3px rgba(0,0,0,0.5), 0 0 4px rgba(209,0,177,0.3), 0 0 8px rgba(209,0,177,0.2)"
+    const normalShadow =
+      "0 0 1px #d100b1, 0 -1px 3px rgba(255,255,255,0.8), 0 1px 3px rgba(0,0,0,0.5), 0 0 15px #d100b1, 0 0 45px rgba(209,0,177,0.8)"
+
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
@@ -45,18 +60,37 @@ const Hero = () => {
                 },
                 ">0.3",
               )
-              .fromTo(
-                subTitleRef.current,
-                { autoAlpha: 0, y: -10, rotate: "-8deg" },
-                {
-                  autoAlpha: 1,
-                  y: 0,
-                  duration: 0.85,
-                  ease: "sine.inout",
-                  rotate: "-8deg",
+              // neon tube warm-up — unlit state: tube is visible but not ionized
+              .set(subTitleRef.current, { autoAlpha: 1, color: unlitColor, textShadow: unlitShadow, rotate: "-8deg" }, ">0.5")
+              // flash 1 — longer burst, fails (120ms ON)
+              .set(subTitleRef.current, { color: litColor, textShadow: flashShadow })
+              .to(subTitleRef.current, { duration: 0.12, ease: "none" })
+              .set(subTitleRef.current, { color: unlitColor, textShadow: unlitShadow })
+              // dark pause (300ms)
+              .to(subTitleRef.current, { duration: 0.3, ease: "none" })
+              // flash 2 — shorter burst, fails (70ms ON)
+              .set(subTitleRef.current, { color: litColor, textShadow: flashShadow })
+              .to(subTitleRef.current, { duration: 0.07, ease: "none" })
+              .set(subTitleRef.current, { color: unlitColor, textShadow: unlitShadow })
+              // dark pause (160ms)
+              .to(subTitleRef.current, { duration: 0.16, ease: "none" })
+              // flash 3a — stutter (50ms ON)
+              .set(subTitleRef.current, { color: litColor, textShadow: flashShadow })
+              .to(subTitleRef.current, { duration: 0.05, ease: "none" })
+              .set(subTitleRef.current, { color: unlitColor, textShadow: unlitShadow })
+              // micro pause (50ms) then catches — glow grows from seed to normal
+              .to(subTitleRef.current, { duration: 0.05, ease: "none" })
+              .set(subTitleRef.current, { color: litColor, textShadow: ignitionShadow })
+              .to(subTitleRef.current, {
+                textShadow: normalShadow,
+                duration: 0.6,
+                ease: "power2.out",
+                onComplete: () => {
+                  // hand off text-shadow control to CSS for the infinite pulse loop
+                  gsap.set(subTitleRef.current, { clearProps: "textShadow,color" })
+                  subTitleRef.current?.classList.add(s.subtitlePulsing)
                 },
-                ">0.2",
-              )
+              })
 
             observer.disconnect()
             break

--- a/src/sections/hero/index.tsx
+++ b/src/sections/hero/index.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { useEffect, useRef } from "react"
+import { useEffect, useRef } from "react"
 import { gsap } from "gsap"
 import { useIsMobile } from "@/hooks/use-media-query"
 import Gradient from "@/components/gradient"
@@ -36,9 +36,23 @@ const Hero = () => {
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
+            const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+
+            if (prefersReducedMotion) {
+              gsap.set(triangleRef.current, { opacity: 1, fillOpacity: 1, strokeOpacity: 1, clearProps: "filter" })
+              triangleRef.current?.classList.add(s.trianglePulsing)
+              gsap.set(titleRef.current, { autoAlpha: 1 })
+              gsap.set(subTitleRef.current, { autoAlpha: 1 })
+              subTitleRef.current?.classList.add(s.subtitlePulsing)
+              observer.disconnect()
+              return
+            }
+
+            const dropY = -(window.innerHeight * 0.35)
+
             tl.current
               // triangle drops from above — invisible, falls hard
-              ?.set(triangleRef.current, { opacity: 1, fillOpacity: 0, strokeOpacity: 0, filter: "none", y: -280 }, "+=0.4")
+              ?.set(triangleRef.current, { opacity: 1, fillOpacity: 0, strokeOpacity: 0, filter: "none", y: dropY }, "+=0.4")
               .to(triangleRef.current, {
                 y: 0,
                 fillOpacity: 1,
@@ -114,7 +128,7 @@ const Hero = () => {
           }
         }
       },
-      { threshold: 0.5 },
+      { threshold: 0.25 },
     )
 
     if (heroSection) {
@@ -124,6 +138,8 @@ const Hero = () => {
     return () => {
       observer.disconnect()
       tl.current?.kill()
+      triangleRef.current?.classList.remove(s.trianglePulsing)
+      subTitleRef.current?.classList.remove(s.subtitlePulsing)
     }
   }, [])
 

--- a/src/sections/hero/index.tsx
+++ b/src/sections/hero/index.tsx
@@ -65,7 +65,7 @@ const Hero = () => {
                 filter: "drop-shadow(0 0 20px #36e2f8) drop-shadow(0 0 60px rgba(54,226,248,0.95))",
               })
               .to(triangleRef.current, {
-                filter: "drop-shadow(0 0 4px #36e2f8) drop-shadow(0 0 14px rgba(54,226,248,0.4))",
+                filter: "drop-shadow(0 0 6px rgba(54,226,248,0.55))",
                 duration: 0.6,
                 ease: "expo.out",
                 onComplete: () => {

--- a/src/sections/hero/index.tsx
+++ b/src/sections/hero/index.tsx
@@ -22,69 +22,86 @@ const Hero = () => {
     const unlitColor = "#3d0a30"
     const litColor = "#d100b1"
     // unlit tube: very faint outline-like shadow, simulates the glass tube shape
-    const unlitShadow =
-      "0 0 1px rgba(180, 20, 140, 0.25), 0 0 3px rgba(180, 20, 140, 0.12)"
+    const unlitShadow = "0 0 1px rgba(180, 20, 140, 0.25), 0 0 3px rgba(180, 20, 140, 0.12)"
     // flash bursts (flashes 1 & 2) — instant, full power
     const flashShadow =
       "0 0 2px #ff00d9, 0 -1px 5px rgba(255,255,255,0.95), 0 1px 3px rgba(0,0,0,0.5), 0 0 30px #d100b1, 0 0 70px rgba(209,0,177,0.95)"
     // seed shadow for the "catches" transition — minimal, glow starts from here
     const ignitionShadow =
-      "0 0 1px rgba(209,0,177,0.4), 0 -1px 2px rgba(255,255,255,0.2), 0 1px 3px rgba(0,0,0,0.5), 0 0 4px rgba(209,0,177,0.3), 0 0 8px rgba(209,0,177,0.2)"
+      "0 0 1px rgba(209,0,177,0.8), 0 -1px 2px rgba(255,255,255,0.55), 0 1px 3px rgba(0,0,0,0.5), 0 0 12px rgba(209,0,177,0.75), 0 0 26px rgba(209,0,177,0.55)"
     const normalShadow =
-      "0 0 1px #d100b1, 0 -1px 3px rgba(255,255,255,0.8), 0 1px 3px rgba(0,0,0,0.5), 0 0 15px #d100b1, 0 0 45px rgba(209,0,177,0.8)"
+      "0 0 1px #d100b1, 0 -1px 3px rgba(255,255,255,0.85), 0 1px 3px rgba(0,0,0,0.5), 0 0 20px #d100b1, 0 0 52px rgba(209,0,177,0.85)"
 
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
             tl.current
-              ?.fromTo(
-                triangleRef.current,
-                { opacity: 0 },
-                { opacity: 1, duration: 0.5, delay: 0.5 },
-              )
+              // triangle drops from above — invisible, falls hard
+              ?.set(triangleRef.current, { opacity: 1, fillOpacity: 0, strokeOpacity: 0, filter: "none", y: -280 }, "+=0.4")
               .to(triangleRef.current, {
-                strokeDashoffset: 0,
-                duration: 0.85,
-                ease: "slowmo.inout",
+                y: 0,
+                fillOpacity: 1,
+                duration: 0.5,
+                ease: "power4.in",
               })
-              .fromTo(
-                titleRef.current,
-                { autoAlpha: 0, scale: 1.2, y: -10 },
-                {
-                  autoAlpha: 1,
-                  scale: 1,
-                  duration: 0.75,
-                  y: 0,
-                  ease: "slowmo.inout",
+              // impact — glow burst fires from the force
+              .set(triangleRef.current, {
+                strokeOpacity: 1,
+                filter: "drop-shadow(0 0 20px #36e2f8) drop-shadow(0 0 60px rgba(54,226,248,0.95))",
+              })
+              .to(triangleRef.current, {
+                filter: "drop-shadow(0 0 4px #36e2f8) drop-shadow(0 0 14px rgba(54,226,248,0.4))",
+                duration: 0.6,
+                ease: "expo.out",
+                onComplete: () => {
+                  gsap.set(triangleRef.current, { clearProps: "filter" })
+                  triangleRef.current?.classList.add(s.trianglePulsing)
                 },
-                ">0.3",
+              })
+              // stamp — GGMANOLO snaps in with chromatic aberration that converges
+              // breathing room: 400ms gap lets the triangle glow settle before the title hits
+              .set(titleRef.current, {
+                autoAlpha: 1, scale: 0.96, y: 0,
+                filter: "drop-shadow(6px 0 0 rgba(255,0,80,0.9)) drop-shadow(-6px 0 0 rgba(0,220,255,0.9))",
+                textShadow: "0 0 30px rgba(255,255,255,0.85)",
+              }, ">0.4")
+              .to(titleRef.current, {
+                scale: 1,
+                filter: "drop-shadow(0px 0 0 rgba(255,0,80,0)) drop-shadow(0px 0 0 rgba(0,220,255,0))",
+                textShadow: "0 0 0px rgba(255,255,255,0)",
+                duration: 0.45,
+                ease: "power2.out",
+              })
+              // neon tube — enters already lit, then flickers unstably before settling
+              // breathing room: 600ms gap after title stamp
+              .set(
+                subTitleRef.current,
+                { autoAlpha: 1, color: litColor, textShadow: normalShadow, rotate: "-8deg" },
+                ">0.6",
               )
-              // neon tube warm-up — unlit state: tube is visible but not ionized
-              .set(subTitleRef.current, { autoAlpha: 1, color: unlitColor, textShadow: unlitShadow, rotate: "-8deg" }, ">0.5")
-              // flash 1 — longer burst, fails (120ms ON)
-              .set(subTitleRef.current, { color: litColor, textShadow: flashShadow })
-              .to(subTitleRef.current, { duration: 0.12, ease: "none" })
+              // on for a moment (250ms) — eye registers it's lit
+              .to(subTitleRef.current, { duration: 0.25, ease: "none" })
+              // flicker 1 — LENTO: drops dark (320ms OFF) — unstable, losing charge
               .set(subTitleRef.current, { color: unlitColor, textShadow: unlitShadow })
-              // dark pause (300ms)
-              .to(subTitleRef.current, { duration: 0.3, ease: "none" })
-              // flash 2 — shorter burst, fails (70ms ON)
+              .to(subTitleRef.current, { duration: 0.32, ease: "none" })
+              // back on — burst (130ms ON)
               .set(subTitleRef.current, { color: litColor, textShadow: flashShadow })
-              .to(subTitleRef.current, { duration: 0.07, ease: "none" })
+              .to(subTitleRef.current, { duration: 0.13, ease: "none" })
+              // flicker 2 — RAPIDO: quick dark (90ms OFF)
               .set(subTitleRef.current, { color: unlitColor, textShadow: unlitShadow })
-              // dark pause (160ms)
-              .to(subTitleRef.current, { duration: 0.16, ease: "none" })
-              // flash 3a — stutter (50ms ON)
+              .to(subTitleRef.current, { duration: 0.09, ease: "none" })
+              // flicker 3 — RAPIDO: micro burst (60ms ON)
               .set(subTitleRef.current, { color: litColor, textShadow: flashShadow })
-              .to(subTitleRef.current, { duration: 0.05, ease: "none" })
+              .to(subTitleRef.current, { duration: 0.06, ease: "none" })
+              // micro dark (50ms) then catches — glow grows from seed to stable
               .set(subTitleRef.current, { color: unlitColor, textShadow: unlitShadow })
-              // micro pause (50ms) then catches — glow grows from seed to normal
               .to(subTitleRef.current, { duration: 0.05, ease: "none" })
               .set(subTitleRef.current, { color: litColor, textShadow: ignitionShadow })
               .to(subTitleRef.current, {
                 textShadow: normalShadow,
-                duration: 0.6,
-                ease: "power2.out",
+                duration: 0.8,
+                ease: "sine.inOut",
                 onComplete: () => {
                   // hand off text-shadow control to CSS for the infinite pulse loop
                   gsap.set(subTitleRef.current, { clearProps: "textShadow,color" })

--- a/src/sections/hero/index.tsx
+++ b/src/sections/hero/index.tsx
@@ -91,7 +91,7 @@ const Hero = () => {
               // breathing room: 600ms gap after title stamp
               .set(
                 subTitleRef.current,
-                { autoAlpha: 1, color: litColor, textShadow: normalShadow, rotate: "-8deg" },
+                { autoAlpha: 1, color: litColor, textShadow: normalShadow },
                 ">0.6",
               )
               // on for a moment (250ms) — eye registers it's lit


### PR DESCRIPTION
## Summary

- Replaces the static hero with a 3-act GSAP animation sequence: triangle drop → GGMANOLO stamp → neon tube flicker
- Adds infinite CSS pulse loops for both the cyan triangle stroke and the pink neon subtitle
- Respects `prefers-reduced-motion` — skips animation and shows elements instantly for users who need it

## What changed

| File | Change |
|------|--------|
| `src/sections/hero/index.tsx` | Full GSAP animation timeline + accessibility fixes |
| `src/sections/hero/hero.module.scss` | `@keyframes neonPulse` + `@keyframes triangleGlow` + `.subtitlePulsing` + `.trianglePulsing` |

## Animation sequence

**1. Triangle** — drops from `-(35% of viewport height)` with `power4.in` (500ms). On impact: cyan glow burst dissipates via `expo.out` (600ms), then hands off to `@keyframes triangleGlow` (4s subtle pulse).

**2. GGMANOLO** — stamps in from `scale: 0.96` with chromatic aberration (±6px red/cyan split) and white flash. Both converge to 0 in 450ms (`power2.out`). 400ms breathing gap after triangle.

**3. Creative Engineer (neon tube)** — enters already lit, flickers unstably: slow dark (320ms) → burst (130ms) → quick dark (90ms) → micro burst (60ms) → catches. Color snaps on instantly; only `textShadow` grows via `sine.inOut` (800ms). Hands off to `@keyframes neonPulse` (3s subtle pulse). 600ms breathing gap after stamp.

## Accessibility & robustness

- `prefers-reduced-motion`: all elements appear instantly with CSS pulse classes, no GSAP sequence
- Drop distance is `window.innerHeight * 0.35` — adapts to mobile landscape and large screens
- `IntersectionObserver` threshold lowered to `0.25` — reliable trigger on mobile
- `classList` cleanup on unmount — no leaks if component is remounted

## Test plan

- [x] Manually tested in browser (desktop + mobile viewport)
- [x] GGA code review passed on all commits
- [x] No TypeScript errors
