### PR TITLE
chore(cv): sync Staff title, add AI context, fix SCSS type error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,14 +28,15 @@ type RootLayoutProps = {
 }
 
 export const metadata = {
-  title: "Manuel Garcia Genta | Senior Frontend & UI Engineer",
+  title: "Manuel Garcia Genta | Staff Frontend Engineer",
   description:
-    "Senior Frontend & UI Engineer specializing in React and Next.js. I build visually refined, high-performance product interfaces with strong design and technical standards.",
+    "Staff Frontend Engineer specializing in React and Next.js. I build visually refined, high-performance product interfaces with strong design, technical standards, and AI-augmented engineering workflows.",
   metadataBase: new URL("https://ggmanolo.com"),
   alternates: {
     canonical: "https://ggmanolo.com",
   },
   keywords: [
+    "Staff Frontend Engineer",
     "Senior Frontend Engineer",
     "UI Engineer",
     "Product Engineer",
@@ -44,7 +45,12 @@ export const metadata = {
     "Frontend Developer",
     "React Developer",
     "Next.js Developer",
-    "UI/UX Designer",
+    "TypeScript Developer",
+    "GSAP Animation",
+    "Tailwind CSS",
+    "Sanity CMS",
+    "Agentic AI Development",
+    "AI-augmented development",
     "Manuel Garcia Genta",
     "GGManolo",
   ],
@@ -102,7 +108,7 @@ const RootLayout = ({ children }: RootLayoutProps) => {
     name: "Manuel Garcia Genta",
     alternateName: "GGManolo",
     description:
-      "Senior Frontend & UI Engineer specializing in React, Next.js and product-driven interfaces.",
+      "Staff Frontend Engineer specializing in React, Next.js and product-driven interfaces with AI-augmented engineering workflows.",
     url: "https://ggmanolo.com",
     image: {
       "@type": "ImageObject",
@@ -111,7 +117,7 @@ const RootLayout = ({ children }: RootLayoutProps) => {
       height: "400",
     },
     sameAs: ["https://www.linkedin.com/in/ggmanolo/", "https://github.com/ggmanolo"],
-    jobTitle: "Senior Frontend Engineer",
+    jobTitle: "Staff Frontend Engineer",
     worksFor: {
       "@type": "Organization",
       name: "Independent / Contract",

--- a/src/sections/about/index.tsx
+++ b/src/sections/about/index.tsx
@@ -20,7 +20,7 @@ const About = () => {
         </div>
         <article className={s.description}>
           <p>
-            I'm a Senior Frontend Engineer with <strong>+{years} years</strong> of experience
+            I'm a Staff Frontend Engineer with <strong>+{years} years</strong> of experience
             building production-ready web applications.
           </p>
           <p>
@@ -32,7 +32,8 @@ const About = () => {
           <p>
             I've led frontend initiatives from scratch, defined architecture for marketing and
             product surfaces, and collaborated closely with design teams in fully remote
-            environments.
+            environments. I also design and implement AI-augmented engineering workflows with
+            project-scoped agent configurations to enforce coding standards at scale.
           </p>
         </article>
         <div className={s.actions}>

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,0 +1,9 @@
+declare module "*.scss" {
+  const styles: Record<string, string>
+  export default styles
+}
+
+declare module "*.css" {
+  const styles: Record<string, string>
+  export default styles
+}


### PR DESCRIPTION
## Summary
Consistency pass to align the website with the updated CV and LinkedIn profile.
- Updated title and job title from "Senior" to "Staff Frontend Engineer" across metadata, structured data, and the About section
- Added AI-augmented workflows context to the About description and structured data
- Added `src/types/globals.d.ts` to fix a pre-existing SCSS side-effect import type error reported by the language server