### PR TITLE
fix(cv): fix broken CV download blocked by CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -27,8 +27,8 @@ const nextConfig: NextConfig = {
       "font-src 'self' https://vercel.live https://assets.vercel.com",
       // Local images + data URIs (inline SVGs) + Vercel toolbar assets
       "img-src 'self' data: https://vercel.live https://vercel.com",
-      // Vercel Analytics + Vercel toolbar websocket/beacon
-      "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com https://vercel.live wss://ws-us3.pusher.com",
+      // Vercel Analytics + Vercel toolbar websocket/beacon + CV download (Google Docs export)
+      "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com https://vercel.live wss://ws-us3.pusher.com https://docs.google.com",
       // Vercel toolbar iframe
       "frame-src https://vercel.live",
       "frame-ancestors 'none'",

--- a/next.config.ts
+++ b/next.config.ts
@@ -29,6 +29,8 @@ const nextConfig: NextConfig = {
       "img-src 'self' data: https://vercel.live https://vercel.com",
       // Vercel Analytics + Vercel toolbar websocket/beacon
       "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com https://vercel.live wss://ws-us3.pusher.com",
+      // Vercel Live toolbar web worker (uses blob: URLs)
+      "worker-src blob:",
       // Vercel toolbar iframe
       "frame-src https://vercel.live",
       "frame-ancestors 'none'",

--- a/next.config.ts
+++ b/next.config.ts
@@ -27,8 +27,8 @@ const nextConfig: NextConfig = {
       "font-src 'self' https://vercel.live https://assets.vercel.com",
       // Local images + data URIs (inline SVGs) + Vercel toolbar assets
       "img-src 'self' data: https://vercel.live https://vercel.com",
-      // Vercel Analytics + Vercel toolbar websocket/beacon + CV download (Google Docs export)
-      "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com https://vercel.live wss://ws-us3.pusher.com https://docs.google.com",
+      // Vercel Analytics + Vercel toolbar websocket/beacon
+      "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com https://vercel.live wss://ws-us3.pusher.com",
       // Vercel toolbar iframe
       "frame-src https://vercel.live",
       "frame-ancestors 'none'",

--- a/src/components/cv/index.tsx
+++ b/src/components/cv/index.tsx
@@ -9,24 +9,13 @@ type DownloadCVProps = {
 const DownloadCV = ({ className }: DownloadCVProps) => {
   const cvUrl =
     "https://docs.google.com/document/d/1WrMCdQJS4F9K_cGo0ywcTvJpiNwFspbOLbD6tek1tUU/export?format=pdf"
-  const cvFilename = "Manuel_Garcia_Genta.pdf"
 
-  const handleDownloadClick = () => {
-    fetch(cvUrl)
-      .then((response) => response.blob())
-      .then((blob) => {
-        const url = window.URL.createObjectURL(new Blob([blob]))
-        const link = document.createElement("a")
-        link.href = url
-        link.setAttribute("download", cvFilename)
-        document.body.appendChild(link)
-        link.click()
-        link.parentNode?.removeChild(link)
-      })
+  const handleOpenClick = () => {
+    window.open(cvUrl, "_blank", "noopener,noreferrer")
   }
 
   return (
-    <button onClick={handleDownloadClick} className={clsx(s.button, className)}>
+    <button onClick={handleOpenClick} className={clsx(s.button, className)}>
       <span>Download Resume</span>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
         <path


### PR DESCRIPTION
## Summary

- Replace `fetch()` + blob pattern with `window.open()` — eliminates CSP `connect-src` violations caused by Google Docs' dynamic redirect chain to `*.googleusercontent.com`
- Revert unnecessary `docs.google.com` in `connect-src` (no longer needed)
- Add `worker-src blob:` to CSP to allow Vercel Live toolbar web worker

| File | Change |
|------|--------|
| `src/components/cv/index.tsx` | Remove fetch/blob logic, replace with `window.open(url, '_blank', 'noopener,noreferrer')` |
| `next.config.ts` | Add `worker-src blob:` directive; revert `docs.google.com` from `connect-src` |

## Root Cause

The CV download broke when the CSP was added (`feat(security): add CSP and Permissions-Policy headers`, April 2026). The `fetch()` call followed a redirect from `docs.google.com` to a dynamic `*.googleusercontent.com` subdomain that can't be safely whitelisted in `connect-src`. Navigation requests (`window.open`) bypass `connect-src` entirely — the browser handles the redirect natively without CSP interference.