### PR TITLE
fix(hero): capture ref values in cleanup to resolve exhaustive-deps warnings

### DIFF
--- a/src/sections/hero/index.tsx
+++ b/src/sections/hero/index.tsx
@@ -17,6 +17,8 @@ const Hero = () => {
   useEffect(() => {
     tl.current = gsap.timeline()
     const heroSection = containerRef.current
+    const triangleEl = triangleRef.current
+    const subTitleEl = subTitleRef.current
 
     // neon color states — mimic the CodePen technique: swap color+shadow, never touch opacity
     const unlitColor = "#3d0a30"
@@ -138,8 +140,8 @@ const Hero = () => {
     return () => {
       observer.disconnect()
       tl.current?.kill()
-      triangleRef.current?.classList.remove(s.trianglePulsing)
-      subTitleRef.current?.classList.remove(s.subtitlePulsing)
+      triangleEl?.classList.remove(s.trianglePulsing)
+      subTitleEl?.classList.remove(s.subtitlePulsing)
     }
   }, [])
 


### PR DESCRIPTION
## Summary

Resolve two `react-hooks/exhaustive-deps` ESLint warnings in the Vercel build logs.

## Changes

| File | Change |
|------|--------|
| `src/sections/hero/index.tsx` | Capture `triangleRef.current` and `subTitleRef.current` into local variables (`triangleEl`, `subTitleEl`) at effect setup time. Use those variables in the cleanup function instead of accessing `.current` directly |

## Root Cause

The `react-hooks/exhaustive-deps` rule warns when a ref's `.current` is read inside a cleanup function — by the time cleanup runs on unmount, the ref may already be null. The fix follows the same pattern already used in the effect for `containerRef.current` → `heroSection`: capture the value once at the top, use the captured variable in cleanup.

The rest of the effect body (IntersectionObserver callback, GSAP animations) is unchanged.