### PR TITLE
fix: deps security patch + avatar GitHub link

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.6.1",
+    "brace-expansion": ">=5.0.5",
     "clsx": "^1.2.1",
     "embla-carousel-react": "^8.6.0",
     "eslint": "^9",
@@ -38,7 +39,7 @@
     "glob": ">=10.5.0",
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
-    "brace-expansion": ">=5.0.5",
+    "brace-expansion": ">=5.0.6",
     "flatted": ">=3.4.0",
     "immutable": ">=5.1.5",
     "postcss": ">=8.5.10"

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react"
 import clsx from "clsx"
 import Image from "next/image"
+import Link from "next/link"
 import Nav from "@/components/nav"
 import s from "./header.module.scss"
 import EmailCta from "../emailCta"
@@ -36,7 +37,13 @@ const Header = () => {
   return (
     <header className={clsx(s.header, scrolled && s.scrolled)}>
       <div className={s.wrapper}>
-        <div className={s.ggmanolo}>
+        <Link
+          href="https://github.com/ggmanolo"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="GitHub profile"
+          className={s.ggmanolo}
+        >
           <Image
             alt="profile"
             src="/img/avatar.png"
@@ -45,7 +52,7 @@ const Header = () => {
             quality={100}
             priority
           />
-        </div>
+        </Link>
         <Nav />
         <EmailCta />
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,9 +862,9 @@ balanced-match@^4.0.2:
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 brace-expansion@>=5.0.5, brace-expansion@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Summary

- Upgrades `brace-expansion` to `5.0.6` to fix CVE-2026-45149 (Moderate). Bumps resolution floor in `package.json` from `>=5.0.5` to `>=5.0.6` and updates `yarn.lock` accordingly.
- Wraps the header avatar in a `<Link>` pointing to the GitHub profile (`github.com/ggmanolo`). Adds `aria-label`, `target="_blank"`, and `rel="noopener noreferrer"`.

| File | Change |
|------|--------|
| `package.json` | Bump `brace-expansion` resolution to `>=5.0.6` |
| `yarn.lock` | Lockfile updated to `brace-expansion@5.0.6` |
| `src/components/header/index.tsx` | Avatar wrapped in `<Link>` → GitHub profile |